### PR TITLE
patchedeyes reference fixes

### DIFF
--- a/Core/GamePatch.cs
+++ b/Core/GamePatch.cs
@@ -1,6 +1,7 @@
 ﻿using HarmonyLib;
 using MoreEyes.EyeManagement;
 using MoreEyes.Menus;
+using Unity.VisualScripting;
 using UnityEngine;
 
 namespace MoreEyes.Core;
@@ -20,7 +21,7 @@ internal class LocalPlayerMenuPatch
 
 //custom assets could probably be loaded before spawn
 //however, vanilla references will need to be created at first spawn
-[HarmonyPatch(typeof(PlayerAvatar), nameof(PlayerAvatar.Spawn))]
+[HarmonyPatch(typeof(PlayerAvatar), nameof(PlayerAvatar.SpawnRPC))]
 internal class PlayerSpawnPatch
 {
     public static void Postfix(PlayerAvatar __instance)
@@ -36,7 +37,7 @@ internal class PlayerSpawnPatch
         if (!PlayerEyeSelection.TryGetSelections(player.steamID, out PlayerEyeSelection selections))
             selections = new(player.steamID);
 
-        PatchedEyes patchedEyes = PatchedEyes.GetPatchedEyes(PlayerAvatar.instance);
+        PatchedEyes patchedEyes = player.AddComponent<PatchedEyes>();
 
         //link these two for easy back and forth
         patchedEyes.currentSelections = selections;

--- a/EyeManagement/CustomPupilType.cs
+++ b/EyeManagement/CustomPupilType.cs
@@ -79,6 +79,7 @@ internal class CustomPupilType
 
     private void AddVanillaEye(GameObject eyeObject)
     {
+        Path = eyeObject.name; //set for getting via rpc?
         Prefab = UnityEngine.Object.Instantiate(eyeObject);
         UnityEngine.Object.DontDestroyOnLoad(Prefab);
         Prefab.transform.SetParent(null);

--- a/EyeManagement/PatchedEyes.cs
+++ b/EyeManagement/PatchedEyes.cs
@@ -1,6 +1,7 @@
 ﻿using MoreEyes.Core;
 using System.Collections.Generic;
 using System.Linq;
+using Unity.VisualScripting;
 using UnityEngine;
 using static MoreEyes.EyeManagement.CustomEyeManager;
 
@@ -13,7 +14,13 @@ internal class PatchedEyes : MonoBehaviour
     internal PlayerAvatar Player { get; private set; } = null!;
     internal static PatchedEyes Local 
     { 
-        get { return PlayerAvatar.instance.GetComponent<PatchedEyes>(); }
+        get 
+        {
+            PatchedEyes local = PlayerAvatar.instance?.GetComponent<PatchedEyes>();
+            if (local == null)
+                return local.AddComponent<PatchedEyes>();
+            return local;
+        }
     }
 
     //Using EyeRef class to track transforms, game objects, and positioning
@@ -21,6 +28,14 @@ internal class PatchedEyes : MonoBehaviour
     internal EyeRef RightEye { get; private set; }
 
     internal PlayerEyeSelection currentSelections = null!;
+
+    private void Awake()
+    {
+        AllPatchedEyes.RemoveAll(p => p.Player == null);
+        Player = GetComponent<PlayerAvatar>();
+        playerID = Player.steamID;
+        AllPatchedEyes.Add(this);
+    }
 
     private void Start()
     {
@@ -45,32 +60,6 @@ internal class PatchedEyes : MonoBehaviour
         LeftEye.SetFirstPupilActual(originalLeft);
         RightEye.SetFirstPupilActual(originalRight);
         
-    }
-
-    //Created this to try to standardize the creation of the component
-    //also to get references to existing components attached to any players
-    //added the playerref bit so that it's a little easier to find by code
-    public static PatchedEyes GetPatchedEyes(PlayerAvatar player)
-    {
-        AllPatchedEyes.RemoveAll(p => p.Player == null);
-        PatchedEyes TryGetFromID = AllPatchedEyes.FirstOrDefault(p => p.playerID == PlayerAvatar.instance.steamID);
-
-        if (TryGetFromID == null)
-        {
-            PatchedEyes tryGetComponent = player.gameObject.GetComponent<PatchedEyes>();
-            if (tryGetComponent != null)
-                return tryGetComponent;
-            else
-            {
-                tryGetComponent = player.gameObject.AddComponent<PatchedEyes>();
-                tryGetComponent.playerID = player.steamID;
-                tryGetComponent.Player = player;
-                AllPatchedEyes.Add(tryGetComponent);
-                return tryGetComponent;
-            } 
-        }
-        else
-            return TryGetFromID;
     }
 
     internal void SetMenuEyes(PlayerAvatarVisuals visuals)
@@ -103,7 +92,7 @@ internal class PatchedEyes : MonoBehaviour
         eye.CreatePupil(newSelection);
         currentSelections.UpdateSelectionOf(isLeft, newSelection);
 
-        FileManager.UpdateWrite = true;
+        //potential RPC here
     }
 
     //used to change existing iris to new selection
@@ -114,7 +103,7 @@ internal class PatchedEyes : MonoBehaviour
         eye.CreateIris(newSelection);
         currentSelections.UpdateSelectionOf(isLeft, newSelection);
 
-        FileManager.UpdateWrite = true;
+        //potential RPC here
     }
 
     internal void SetSelectedEyes(PlayerAvatar player)


### PR DESCRIPTION
non-host should now properly create their patchedeyes refs with the entrypoint being SpawnRpc and not Spawn got rid of GetPatchedEyes static method in favor of assigning stuff at awake and just creating the component on spawn